### PR TITLE
Refactor build bootable artifacts

### DIFF
--- a/.github/actions/build-bootable-artifacts/action.yml
+++ b/.github/actions/build-bootable-artifacts/action.yml
@@ -1,5 +1,5 @@
 ---
-name: Build ISO
+name: Build bootable artifacts
 
 inputs:
   platform:
@@ -9,8 +9,12 @@ inputs:
     description: Full podman image reference, including hash (e.g., "registry.example.com/image@sha256")
     required: true
   image-name:
-    description: Name of the image, will be used to name the ISO file (e.g., "my-image")
+    description: Name of the image, will be used to name the artifact files (e.g., "my-image")
     required: true
+  image-types:
+    description: The types of bootable artifacts to build (e.g., "iso,raw")
+    required: false
+    default: "iso"
   update_is_signed:
     description: Whether the image is signed or not
     required: false
@@ -18,10 +22,13 @@ inputs:
     description: Image reference to update from (e.g., "{image}:latest")
     required: true
   config-file:
-    description: Path to the ISO configuration file
+    description: Path to the bootable artifacts configuration file
     required: true
-  use_librepo:
+  use-librepo:
     description: "Use librepo to download the image"
+    required: false
+  additional-args:
+    description: "Additional arguments to pass to the bootc-image-builder"
     required: false
   REGISTRY:
     description: The container registry URL (e.g., "registry.example.com")
@@ -35,17 +42,11 @@ inputs:
 
 outputs:
   output_directory:
-    description: The directory where the built ISO and checksum are stored
+    description: The directory where the built artifacts and checksums are stored
     value: ${{ steps.rename.outputs.output_directory }}
-  artifact_name:
-    description: The name of the artifact (ISO file) without the extension
-    value: ${{ steps.rename.outputs.ARTIFACT_NAME }}
-  iso_name:
-    description: The name of the built ISO file
-    value: ${{ steps.rename.outputs.ISO_NAME }}
-  checksum_name:
-    description: The name of the checksum file for the ISO
-    value: ${{ steps.rename.outputs.CHECKSUM_NAME }}
+  artifact_basename:
+    description: The base name of the artifacts
+    value: ${{ steps.rename.outputs.artifact_basename }}
 
 runs:
   using: "composite"
@@ -64,7 +65,7 @@ runs:
         ARCH=${{ inputs.platform }}
         echo "CLEAN_ARCH=${ARCH//\//_}" >> "$GITHUB_ENV"
 
-    - name: Prepare ISO configuration
+    - name: Prepare bootable artifacts configuration
       shell: bash
       run: |
         [ "${{ inputs.update_is_signed }}" = "true" ] && SIG="--enforce-container-sigpolicy"
@@ -73,36 +74,42 @@ runs:
         sed -i "s#<IMAGE_SIGNED>#${SIG}#g" ${{ inputs.config-file }}
         cat ${{ inputs.config-file }}
 
-    - name: Build ISO
-      id: build
-      #uses: ublue-os/bootc-image-builder-action@b98784c42327746e107a6a753b64f44823bdbf2f
-      uses: alexiri/bootc-image-builder-action@platform
-      with:
-        image: ${{ inputs.image }}
-        type: iso
-        use-librepo: ${{ inputs.use_librepo }}
-        config-file: ${{ inputs.config-file }}
-        platform: linux/${{ inputs.platform }}
+        [ "${{ inputs.use-librepo }}" = "true" ] && USE_LIBREPO="True" || USE_LIBREPO="False"
+        ADDITIONAL_ARGS="--target-arch=${{ env.CLEAN_ARCH }} --use-librepo=${USE_LIBREPO} ${{ inputs.additional-args }}"
 
-    - name: Rename ISO
+        echo "ADDITIONAL_ARGS=${ADDITIONAL_ARGS}" >> "$GITHUB_ENV"
+
+    - name: Build bootable artifacts
+      id: build
+      uses: osbuild/bootc-image-builder-action@4503a3445240ffc85cccf8f57d7cab5634e351e2
+      with:
+        config-file: ${{ inputs.config-file }}
+        image: ${{ inputs.image }}
+        additional-args: ${{ env.ADDITIONAL_ARGS }}
+        types: ${{ inputs.image-types }}
+
+    - name: Rename bootable artifacts
       id: rename
       env:
-        IMAGE_NAME: ${{ inputs.image-name }}-${{ env.CLEAN_ARCH }}-live.iso
         OUTPUT_PATH: output-${{ env.CLEAN_ARCH }}
       shell: bash
       run: |
         set -x
         mkdir -p ${{ env.OUTPUT_PATH }}
         OUTPUT_DIRECTORY="$(realpath ${{ env.OUTPUT_PATH }})"
+        ARTIFACT_BASENAME="${{ inputs.image-name }}-${{ env.CLEAN_ARCH }}"
 
-        ARTIFACT_NAME="${{ inputs.image-name }}-${{ env.CLEAN_ARCH }}"
-        ISO_NAME="${ARTIFACT_NAME}.iso"
-        CHECKSUM_NAME="${ISO_NAME}-CHECKSUM"
+        echo '${{ steps.build.outputs.output-paths }}' | jq -c '.[]' | while read -r artifact; do
+          ARTIFACT_PATH=$(echo "$artifact" | jq -r '.path')
+          ARTIFACT_CHECKSUM=$(echo "$artifact" | jq -r '.checksum')
+          ARTIFACT_EXTENSION=$(echo "$ARTIFACT_PATH" | awk -F. '{print $NF}')
 
-        mv ${{ steps.build.outputs.output-path }} "${OUTPUT_DIRECTORY}/${ISO_NAME}"
-        mv ${{ steps.build.outputs.checksum-path }} "${OUTPUT_DIRECTORY}/${CHECKSUM_NAME}"
+          ARTIFACT_NAME="${ARTIFACT_BASENAME}.${ARTIFACT_EXTENSION}"
+          CHECKSUM_NAME="${ARTIFACT_NAME}-CHECKSUM"
 
-        echo "output_directory=$OUTPUT_DIRECTORY" >> "${GITHUB_OUTPUT}"
-        echo "ISO_NAME=${ISO_NAME}" >> "${GITHUB_OUTPUT}"
-        echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> "${GITHUB_OUTPUT}"
-        echo "CHECKSUM_NAME=${CHECKSUM_NAME}" >> "${GITHUB_OUTPUT}"
+          cp "$ARTIFACT_PATH" "${OUTPUT_DIRECTORY}/${ARTIFACT_NAME}"
+          echo "$ARTIFACT_CHECKSUM" > "${OUTPUT_DIRECTORY}/${CHECKSUM_NAME}"
+        done
+
+        echo "output_directory=${OUTPUT_DIRECTORY}" >> "${GITHUB_OUTPUT}"
+        echo "artifact_basename=${ARTIFACT_BASENAME}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -7,10 +7,19 @@ inputs:
     required: true
   variant:
     description: The variant of the image to build
-    required: true
+    required: false
+    default: ""
   containerfile:
     description: The path to the Containerfile used for building the image
     required: true
+  stage:
+    description: The stage to build in the Containerfile
+    required: false
+    default: ""
+  extra-args:
+    description: Additional arguments to pass to the podman build command
+    required: false
+    default: ""
   image-name:
     description: The name of the image to build
     required: true
@@ -99,6 +108,8 @@ runs:
       shell: bash
       env:
         IMAGE_TAG: ${{ inputs.image-tag }}-${{ env.CLEAN_ARCH }}
+        STAGE_ARGS: --target=${{ inputs.stage }}
+        EXTRA_ARGS: ${{ inputs.extra-args }}
       run: |
         echo "::group::Build Image"
         sudo podman build \
@@ -113,6 +124,8 @@ runs:
           --build-arg VARIANT=${{ inputs.variant }} \
           -t ${{ inputs.image-name }}:${IMAGE_TAG} \
           -f ${{ inputs.containerfile }} \
+          ${{ env.STAGE_ARGS }} \
+          ${{ env.EXTRA_ARGS }} \
           .
 
         echo "image-id=$(cat /tmp/image-id)" >> $GITHUB_OUTPUT

--- a/.github/actions/upload-gh/action.yml
+++ b/.github/actions/upload-gh/action.yml
@@ -2,8 +2,8 @@
 name: Upload to GitHub Actions Artifacts
 
 inputs:
-  artifact_name:
-    description: "The name of the artifact to upload"
+  artifact_basename:
+    description: "The basename of the artifacts to upload"
     required: true
   directory:
     description: "The directory containing the files to upload"
@@ -12,11 +12,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Upload ISOs and Checksum to Job Artifacts
+    - name: Upload Bootable Artifacts and Checksums to Job Artifacts
       id: upload-gh
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4
       with:
-        name: ${{ inputs.artifact_name }}
+        name: ${{ inputs.artifact_basename }}
         path: ${{ inputs.directory }}
         if-no-files-found: error
         compression-level: 0
@@ -26,5 +26,5 @@ runs:
     - name: Summary
       shell: bash
       run: |
-        echo "Artifact URL: ${{ steps.upload-gh.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
+        echo "Artifact: ${{ steps.upload-gh.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY
         echo "Digest: ${{ steps.upload-gh.outputs.artifact-digest }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/upload-r2/action.yml
+++ b/.github/actions/upload-r2/action.yml
@@ -8,6 +8,10 @@ inputs:
   bucket:
     description: "The Cloudflare R2 bucket to upload the files to"
     required: true
+  path:
+    description: "The path to the files to upload, relative to the bucket root"
+    required: true
+    default: ""
   R2_ACCOUNT_ID:
     description: "The Cloudflare R2 account ID"
     required: true
@@ -30,4 +34,4 @@ runs:
         r2-secret-access-key: ${{ inputs.R2_SECRET_ACCESS_KEY }}
         r2-bucket: ${{ inputs.bucket }}
         source-dir: ${{ inputs.directory }}
-        destination-dir: ./
+        destination-dir: ${{ inputs.path }}

--- a/.github/actions/upload-s3/action.yml
+++ b/.github/actions/upload-s3/action.yml
@@ -6,17 +6,12 @@ inputs:
     description: "The directory containing the files to upload"
     required: true
   bucket:
-    description: "The Cloudflare R2 bucket to upload the files to"
+    description: "The Amazon S3 bucket to upload the files to"
     required: true
   path:
-    description: "The path to the files to upload, relative to the directory"
+    description: "The path to the files to upload, relative to the bucket root"
     required: true
-  iso-name:
-    description: "The name of the ISO file to upload"
-    required: true
-  checksum-name:
-    description: "The name of the checksum file to upload"
-    required: true
+    default: ""
   aws-default-region:
     description: "The AWS region to use for S3 uploads"
     required: true
@@ -46,18 +41,4 @@ runs:
         # Upload the files to S3 bucket
         aws s3 cp ${{ inputs.directory }} \
             s3://${BUCKET}/${{ inputs.path }}/ \
-            --recursive
-
-          # Make them uploaded file publicly available
-        aws s3api put-object-tagging \
-            --bucket ${BUCKET} \
-            --key ${{ inputs.path }}/${{ inputs.iso-name }} \
-            --tagging 'TagSet={Key=public,Value=yes}'
-
-        aws s3api put-object-tagging \
-            --bucket ${BUCKET} \
-            --key ${{ inputs.path }}/${{ inputs.checksum-name }} \
-            --tagging 'TagSet={Key=public,Value=yes}'
-
-        echo "ISO: https://${BUCKET}.s3-accelerate.dualstack.amazonaws.com/${{ inputs.path }}/${{ inputs.iso-name }}" >> $GITHUB_STEP_SUMMARY
-        echo "Digest: https://${BUCKET}.s3-accelerate.dualstack.amazonaws.com/${{ inputs.path }}/${{ inputs.checksum-name }}" >> $GITHUB_STEP_SUMMARY
+            --recursive --acl public-read

--- a/.github/workflows/build-bootable-artifacts.yml
+++ b/.github/workflows/build-bootable-artifacts.yml
@@ -1,4 +1,4 @@
-name: Build ISO
+name: Build bootable artifacts
 on:
   workflow_call:
     inputs:
@@ -7,9 +7,14 @@ on:
         required: true
         type: string
       image-name:
-        description: "Name of the image, will be used to name the file name ISO"
+        description: "Name of the image, will be used to name the artifact files"
         required: true
         type: string
+      image-types:
+        description: "The types of bootable artifacts to build (ie: iso,raw)"
+        required: false
+        type: string
+        default: "iso"
       update_origin_ref:
         description: "Image reference to update from (ie: {image}:latest)"
         required: false
@@ -20,7 +25,7 @@ on:
         type: boolean
         default: true
       config-file:
-        description: "Path to the ISO configuration file"
+        description: "Path to the bootable artifacts configuration file"
         required: true
         type: string
       platforms:
@@ -28,11 +33,15 @@ on:
         required: false
         type: string
         default: "amd64,arm64"
-      use_librepo:
+      use-librepo:
         description: "Use librepo to download the image"
         required: false
         type: boolean
         default: false
+      additional-args:
+        description: "Additional arguments to pass to the bootc-image-builder"
+        required: false
+        type: string
       REGISTRY_USER:
         description: "The username to use for the registry"
         required: false
@@ -44,26 +53,26 @@ on:
         type: string
         default: "ghcr.io"
       upload-to-github:
-        description: "Upload the ISO to GitHub Actions artifacts"
+        description: "Upload the artifacts to GitHub Actions artifacts"
         required: false
         type: boolean
         default: true
       upload-to-cloudflare:
-        description: "Upload the ISO to Cloudflare"
+        description: "Upload the artifacts to Cloudflare"
         required: false
         type: boolean
         default: false
       upload-to-s3:
-        description: "Upload the ISO to S3"
+        description: "Upload the artifacts to S3"
         required: false
         type: boolean
         default: false
-      s3-path:
-        description: "The path to upload the ISO to in S3"
+      bucket:
+        description: "The S3/R2 bucket to upload the artifacts to"
         required: false
         type: string
-      bucket:
-        description: "The S3/R2 bucket to upload the ISO to"
+      path:
+        description: "The path to upload the artifacts to in S3/R2"
         required: false
         type: string
       aws-default-region:
@@ -120,7 +129,7 @@ jobs:
           done
           echo "matrix=$(echo $MATRIX | jq -c '.')" >> $GITHUB_OUTPUT
 
-  build-iso:
+  build-bootable-artifacts:
     runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     needs: generate_matrix
     strategy:
@@ -142,17 +151,19 @@ jobs:
           ref: ${{ env.INTERNAL_ACTIONS_REF }}
           path: github-actions
 
-      - name: Build ISO
-        id: build-iso
-        uses: ./github-actions/.github/actions/build-iso
+      - name: Build bootable artifacts
+        id: build-bootable-artifacts
+        uses: ./github-actions/.github/actions/build-bootable-artifacts
         with:
           image: ${{ inputs.image }}
           image-name: ${{ inputs.image-name }}
+          image-types: ${{ inputs.image-types }}
           update_origin_ref: ${{ inputs.update_origin_ref }}
           update_is_signed: ${{ inputs.update_is_signed }}
           config-file: ${{ inputs.config-file }}
           platform: ${{ matrix.platform }}
-          use_librepo: ${{ inputs.use_librepo }}
+          use-librepo: ${{ inputs.use-librepo }}
+          additional-args: ${{ inputs.additional-args }}
           REGISTRY: ${{ inputs.REGISTRY }}
           REGISTRY_USER: ${{ inputs.REGISTRY_USER }}
           REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}
@@ -161,15 +172,16 @@ jobs:
         if: inputs.upload-to-github == true
         uses: ./github-actions/.github/actions/upload-gh
         with:
-          artifact_name: ${{ steps.build-iso.outputs.artifact_name }}
-          directory: ${{ steps.build-iso.outputs.output_directory }}
+          artifact_basename: ${{ steps.build-bootable-artifacts.outputs.artifact_basename }}
+          directory: ${{ steps.build-bootable-artifacts.outputs.output_directory }}
 
       - name: Upload to Cloudflare
         if: inputs.upload-to-cloudflare == true
         uses: ./github-actions/.github/actions/upload-r2
         with:
-          directory: ${{ steps.build-iso.outputs.output_directory }}
+          directory: ${{ steps.build-bootable-artifacts.outputs.output_directory }}
           bucket: ${{ inputs.bucket }}
+          path: ${{ inputs.path }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS_KEY }}
@@ -178,10 +190,8 @@ jobs:
         if: inputs.upload-to-s3 == true
         uses: ./github-actions/.github/actions/upload-s3
         with:
-          directory: ${{ steps.build-iso.outputs.output_directory }}
+          directory: ${{ steps.build-bootable-artifacts.outputs.output_directory }}
           bucket: ${{ inputs.bucket }}
-          path: ${{ inputs.s3-path }}
+          path: ${{ inputs.path }}
           aws-default-region: ${{ inputs.aws-default-region }}
-          iso-name: ${{ steps.build-iso.outputs.iso_name }}
-          checksum-name: ${{ steps.build-iso.outputs.checksum_name }}
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -81,6 +81,16 @@ on:
         description: "The AWS region to use for signing the image"
         required: false
         type: string
+      INTERNAL_ACTIONS_REPO:
+        description: "The repository that contains the internal actions used in this workflow"
+        required: false
+        type: string
+        default: AlmaLinux/atomic-ci
+      INTERNAL_ACTIONS_REF:
+        description: "The ref to use for the internal actions repository"
+        required: false
+        type: string
+        default: v11
     outputs:
       image-ref:
         description: "The image reference of the built image"
@@ -114,7 +124,8 @@ env:
   IMAGE_REGISTRY: ${{ inputs.REGISTRY }}
   IMAGE_PATH: ${{ inputs.image-path }}
   SIGNING_ENABLED: ${{ (secrets.SIGNING_SECRET != null && secrets.SIGNING_SECRET != '') || inputs.KMS_KEY_ALIAS != '' }}
-  INTERNAL_ACTIONS_REF: v11
+  INTERNAL_ACTIONS_REPO: ${{ inputs.INTERNAL_ACTIONS_REPO }}
+  INTERNAL_ACTIONS_REF: ${{ inputs.INTERNAL_ACTIONS_REF }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-${{ inputs.image-name }}
@@ -134,7 +145,7 @@ jobs:
       - name: Checkout github actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
-          repository: AlmaLinux/atomic-ci
+          repository: ${{ env.INTERNAL_ACTIONS_REPO }}
           ref: ${{ env.INTERNAL_ACTIONS_REF }}
           path: github-actions
 
@@ -175,7 +186,7 @@ jobs:
       - name: Checkout github actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
-          repository: AlmaLinux/atomic-ci
+          repository: ${{ env.INTERNAL_ACTIONS_REPO }}
           ref: ${{ env.INTERNAL_ACTIONS_REF }}
           path: github-actions
 
@@ -240,7 +251,7 @@ jobs:
       - name: Checkout github actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
-          repository: AlmaLinux/atomic-ci
+          repository: ${{ env.INTERNAL_ACTIONS_REPO }}
           ref: ${{ env.INTERNAL_ACTIONS_REF }}
           path: github-actions
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -6,6 +6,14 @@ on:
         description: "The path to the Containerfile"
         required: true
         type: string
+      stage:
+        description: The stage to build in the Containerfile
+        required: false
+        type: string
+      extra-args:
+        description: Additional arguments to pass to the podman build command
+        required: false
+        type: string
       image-name:
         description: "The name of the image to build"
         required: true
@@ -197,6 +205,8 @@ jobs:
           platform: ${{ matrix.platform }}
           variant: ${{ inputs.variant }}
           containerfile: ${{ inputs.containerfile }}
+          stage: ${{ inputs.stage }}
+          extra-args: ${{ inputs.extra-args }}
           image-name: ${{ inputs.image-name }}
           image-path: ${{ inputs.image-path }}
           image-tag: ${{ needs.generate_matrix.outputs.tag }}
@@ -228,7 +238,6 @@ jobs:
           KMS_KEY_ALIAS: ${{ inputs.KMS_KEY_ALIAS }}
           AWS_REGION: ${{ inputs.AWS_REGION }}
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-
 
   manifest:
     name: Create Manifest

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -70,6 +70,16 @@ on:
         description: "The AWS region to use for S3 uploads"
         required: false
         type: string
+      INTERNAL_ACTIONS_REPO:
+        description: "The repository that contains the internal actions used in this workflow"
+        required: false
+        type: string
+        default: AlmaLinux/atomic-ci
+      INTERNAL_ACTIONS_REF:
+        description: "The ref to use for the internal actions repository"
+        required: false
+        type: string
+        default: v11
     secrets:
       REGISTRY_TOKEN:
         description: "The token to use for the registry"
@@ -88,7 +98,8 @@ on:
         required: false
 
 env:
-  INTERNAL_ACTIONS_REF: v11
+  INTERNAL_ACTIONS_REPO: ${{ inputs.INTERNAL_ACTIONS_REPO }}
+  INTERNAL_ACTIONS_REF: ${{ inputs.INTERNAL_ACTIONS_REF }}
 
 jobs:
   generate_matrix:
@@ -127,7 +138,7 @@ jobs:
       - name: Checkout github actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
         with:
-          repository: AlmaLinux/atomic-ci
+          repository: ${{ env.INTERNAL_ACTIONS_REPO }}
           ref: ${{ env.INTERNAL_ACTIONS_REF }}
           path: github-actions
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           mkdir -p "${{ steps.download-sbom.outputs.download-path }}" && cd $_
           for f in *.spdx.json; do
-            gzip -9 "$f"
+            gzip -9 "$f" || true
           done
 
       - name: Prepare Release


### PR DESCRIPTION
still in draft phase, but i think it's better to get reviewed while in progress.

mainly intended to implement https://github.com/AlmaLinux/atomic-ci/issues/71 with multi-stage build support and other image types other than anaconda-iso such as raw or bootc-installer (including renaming build-iso to build-bootable-artifacts).

also minor refactorings for some action input formats and simplification of artifact uploads.

first commit is for easier testing on forked repository.